### PR TITLE
Map countries in tryton to countries from magento #2001

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,6 +12,7 @@ from .magento_ import (
     Instance, InstanceWebsite, WebsiteStore, WebsiteStoreView,
     TestConnectionStart, TestConnection,
 )
+from country import Country
 
 
 def register():
@@ -24,6 +25,7 @@ def register():
         WebsiteStore,
         WebsiteStoreView,
         TestConnectionStart,
+        Country,
         module='magento', type_='model'
     )
     Pool.register(

--- a/country.py
+++ b/country.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""
+    country
+
+    Country
+
+    :copyright: (c) 2013 by Openlabs Technologies & Consulting (P) Limited
+    :license: BSD, see LICENSE for more details.
+"""
+from trytond.pool import PoolMeta
+
+
+__all__ = ['Country']
+__metaclass__ = PoolMeta
+
+
+class Country:
+    "Country"
+    __name__ = 'country.country'
+
+    @classmethod
+    def __setup__(cls):
+        """
+        Setup the class before adding to pool
+        """
+        super(Country, cls).__setup__()
+        cls._error_messages.update({
+            'country_not_found': 'Country with ISO code %s does not exist.',
+        })
+
+    @classmethod
+    def search_using_magento_code(cls, code):
+        """
+        Searches for country with given magento code.
+
+        :param code: ISO code of country
+        :return: Browse record of country if found else raises error
+        """
+        countries = cls.search([('code', '=', code)])
+
+        if not countries:
+            return cls.raise_user_error(
+                "country_not_found", error_args=(code, )
+            )
+
+        return countries[0]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,7 @@ import trytond.tests.test_tryton
 
 from tests.test_views import TestViewDepend
 from tests.test_models import TestModels
+from tests.test_country import TestCountry
 
 
 def suite():
@@ -22,6 +23,7 @@ def suite():
     test_suite.addTests([
         unittest.TestLoader().loadTestsFromTestCase(TestViewDepend),
         unittest.TestLoader().loadTestsFromTestCase(TestModels),
+        unittest.TestLoader().loadTestsFromTestCase(TestCountry),
     ])
     return test_suite
 

--- a/tests/test_country.py
+++ b/tests/test_country.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""
+    test_country
+
+    Tests country
+
+    :copyright: (c) 2013 by Openlabs Technologies & Consulting (P) Limited
+    :license: BSD, see LICENSE for more details.
+"""
+import sys
+import os
+DIR = os.path.abspath(os.path.normpath(
+    os.path.join(
+        __file__, '..', '..', '..', '..', '..', 'trytond'
+    )
+))
+if os.path.isdir(DIR):
+    sys.path.insert(0, os.path.dirname(DIR))
+
+import unittest
+
+import trytond.tests.test_tryton
+from trytond.tests.test_tryton import POOL, DB_NAME, USER, CONTEXT
+from trytond.transaction import Transaction
+from trytond.exceptions import UserError
+
+
+class TestCountry(unittest.TestCase):
+    """
+    Tests country
+    """
+
+    def setUp(self):
+        """
+        Set up data used in the tests.
+        this method is called before each test function execution.
+        """
+        trytond.tests.test_tryton.install_module('magento')
+
+    def test_0010_search_country_with_valid_code(self):
+        """
+        Tests if country can be searched using magento code
+        """
+        Country = POOL.get('country.country')
+
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+
+            country = Country.create([{
+                'name': 'United States',
+                'code': 'US',
+            }])
+            self.assert_(country)
+
+            code = 'US'
+
+            country, = Country.search([('code', '=', code)])
+
+            self.assertEqual(
+                Country.search_using_magento_code(code),
+                country
+            )
+
+    def test_0020_search_country_with_invalid_code(self):
+        """
+        Tests if error is raised for searching country with invalid code
+        """
+        Country = POOL.get('country.country')
+
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+
+            code = 'abc'
+
+            self.assertFalse(Country.search([('code', '=', code)]))
+
+            self.assertRaises(
+                UserError,
+                Country.search_using_magento_code, code
+            )
+
+
+def suite():
+    """
+    Test Suite
+    """
+    test_suite = trytond.tests.test_tryton.suite()
+    test_suite.addTests(
+        unittest.TestLoader().loadTestsFromTestCase(TestCountry)
+    )
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())


### PR DESCRIPTION
This patch has implemented a method to search country using magento code
that will return browse record of country if found else will raise
error.

Review ID: 274001
