### PR TITLE
Update products from magento #2075

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,7 +15,7 @@ from magento_ import (
 from party import Party, MagentoWebsiteParty, Address
 from product import (
     Category, MagentoInstanceCategory, Template, MagentoWebsiteTemplate,
-    ImportCatalogStart, ImportCatalog
+    ImportCatalogStart, ImportCatalog, UpdateCatalogStart, UpdateCatalog
 )
 from country import Country, Subdivision
 from sale import MagentoOrderState
@@ -43,11 +43,13 @@ def register():
         ImportCatalogStart,
         MagentoOrderState,
         Address,
+        UpdateCatalogStart,
         module='magento', type_='model'
     )
     Pool.register(
         TestConnection,
         ImportWebsites,
         ImportCatalog,
+        UpdateCatalog,
         module='magento', type_='wizard'
     )

--- a/magento.xml
+++ b/magento.xml
@@ -93,15 +93,15 @@
             action="act_store_form" id="menu_store_form"/>
 
         <!--Website Template-->
-        <record model="ir.ui.view" id="website_template_form">
+        <record model="ir.ui.view" id="magento_product_template_form">
             <field name="model">magento.website.template</field>
             <field name="type">form</field>
-            <field name="name">website_template_form</field>
+            <field name="name">magento_product_template_form</field>
         </record>
-        <record model="ir.ui.view" id="website_template_tree">
+        <record model="ir.ui.view" id="magento_product_template_tree">
             <field name="model">magento.website.template</field>
             <field name="type">tree</field>
-            <field name="name">website_template_tree</field>
+            <field name="name">magento_product_template_tree</field>
         </record>
 
         <!--Website Store View-->

--- a/magento_.py
+++ b/magento_.py
@@ -222,6 +222,10 @@ class InstanceWebsite(ModelSQL, ModelView):
     magento_root_category_id = fields.Integer(
         'Magento Root Category ID', required=True
     )
+    magento_product_templates = fields.One2Many(
+        'magento.website.template', 'website', 'Magento Product Templates',
+        readonly=True
+    )
 
     def get_company(self, name):
         """

--- a/product.xml
+++ b/product.xml
@@ -50,6 +50,22 @@ this repository contains the full copyright notices and license terms. -->
             <field name="name">instance_import_catalog_start_form</field>
         </record>
 
+        <record model="ir.action.wizard" id="wizard_instance_update_catalog">
+            <field name="name">Update Catalog</field>
+            <field name="wiz_name">magento.instance.update_catalog</field>
+            <field name="model">magento.instance.website</field>
+        </record>
+        <record model="ir.action.keyword" id="instance_update_catalog_keyword">
+            <field name="keyword">form_action</field>
+            <field name="model">magento.instance.website,-1</field>
+            <field name="action" ref="wizard_instance_update_catalog"/>
+        </record>
+        <record model="ir.ui.view" id="update_catalog_start">
+            <field name="model">magento.instance.update_catalog.start</field>
+            <field name="type">form</field>
+            <field name="name">update_catalog_start_form</field>
+        </record>
+
         <record id="product_category_magento_unclassified" model="product.category">
             <field name="name">Unclassified Magento Products</field>
         </record>

--- a/view/magento_product_template_form.xml
+++ b/view/magento_product_template_form.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0"?>
 <!-- This file is part of Tryton. The COPYRIGHT file at the top level of
 this repository contains the full copyright notices and license terms. -->
-<form string="Website Product Template">
+<form string="Website Product Template" col="6">
     <label name="magento_id"/>
     <field name="magento_id"/>
     <label name="website"/>
     <field name="website"/>
     <label name="template"/>
     <field name="template"/>
+    <newline/>
+    <button name="update_product_from_magento" string="Update from Magento"/>
 </form>

--- a/view/magento_product_template_tree.xml
+++ b/view/magento_product_template_tree.xml
@@ -5,4 +5,5 @@ this repository contains the full copyright notices and license terms. -->
     <field name="magento_id"/>
     <field name="website"/>
     <field name="template"/>
+    <button name="update_product_from_magento" string="Update from Magento"/>
 </tree>

--- a/view/template_form.xml
+++ b/view/template_form.xml
@@ -7,6 +7,8 @@ this repository contains the full copyright notices and license terms. -->
         <field name="magento_product_type"/>
     </xpath>
     <xpath expr="/form/notebook/page[@id='general']" position="after">
-        <field name="magento_ids" mode="tree,form"/>
+        <page string="Magento" id="magento_product_templates">
+            <field name="magento_ids"/>
+        </page>
     </xpath>
 </data>

--- a/view/update_catalog_start_form.xml
+++ b/view/update_catalog_start_form.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<form string="Update Catalog" col="2">
+    <image name="tryton-dialog-information" xexpand="0" xfill="0"/>
+    <label string="This wizard will update all the product for this website with any details which have been updated on magento"
+        id="choose" yalign="0.0" xalign="0.0" xexpand="1"/>
+</form>

--- a/view/website_form.xml
+++ b/view/website_form.xml
@@ -15,5 +15,8 @@
         <page string="Stores" id="stores">
             <field name="stores"/>
         </page>
+        <page string="Magento Product Templates" id="magento_product_templates">
+            <field name="magento_product_templates"/>
+        </page>
     </notebook>
 </form>


### PR DESCRIPTION
This patch allows updation of products when the catalog update is called
and the product already exists in tryton. It also allow updation of
products from websites. This allows user to choose which website info
will be used as the principal value.

Review ID: 313001
