### PR TITLE
Find currency using magento code #2169

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,6 +19,7 @@ from product import (
 )
 from country import Country, Subdivision
 from sale import MagentoOrderState
+from currency import Currency
 
 
 def register():
@@ -44,6 +45,7 @@ def register():
         MagentoOrderState,
         Address,
         UpdateCatalogStart,
+        Currency,
         module='magento', type_='model'
     )
     Pool.register(

--- a/currency.py
+++ b/currency.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+    currency
+
+    Currency
+
+    :copyright: (c) 2013 by Openlabs Technologies & Consulting (P) Limited
+    :license: BSD, see LICENSE for more details.
+"""
+from trytond.pool import PoolMeta
+
+
+__all__ = ['Currency']
+__metaclass__ = PoolMeta
+
+
+class Currency:
+    "Currency"
+    __name__ = 'currency.currency'
+
+    @classmethod
+    def __setup__(cls):
+        """
+        Setup the class before adding to pool
+        """
+        super(Currency, cls).__setup__()
+        cls._error_messages.update({
+            'currency_not_found': 'Currency with code %s does not exist.',
+        })
+
+    @classmethod
+    def search_using_magento_code(cls, currency_code):
+        """
+        Search for currency with given magento currency code.
+
+        :param currency_code: currency code given by magento
+        :return: Active record of currency if found else raises error
+        """
+        currencies = cls.search([('code', '=', currency_code)])
+
+        if not currencies:
+            return cls.raise_user_error('currency_not_found', (currency_code, ))
+
+        return currencies[0]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,6 +17,7 @@ from tests.test_party import TestParty
 from tests.test_website_import import TestWebsiteImport
 from tests.test_product import TestProduct
 from tests.test_sale import TestSale
+from tests.test_currency import TestCurrency
 
 
 def suite():
@@ -32,6 +33,7 @@ def suite():
         unittest.TestLoader().loadTestsFromTestCase(TestWebsiteImport),
         unittest.TestLoader().loadTestsFromTestCase(TestProduct),
         unittest.TestLoader().loadTestsFromTestCase(TestSale),
+        unittest.TestLoader().loadTestsFromTestCase(TestCurrency),
     ])
     return test_suite
 

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""
+    test_currency
+
+    Tests Currency
+
+    :copyright: (c) 2013 by Openlabs Technologies & Consulting (P) Limited
+    :license: BSD, see LICENSE for more details.
+"""
+import sys
+import os
+from decimal import Decimal
+DIR = os.path.abspath(os.path.normpath(
+    os.path.join(
+        __file__, '..', '..', '..', '..', '..', 'trytond'
+    )
+))
+if os.path.isdir(DIR):
+    sys.path.insert(0, os.path.dirname(DIR))
+
+import unittest
+
+import trytond.tests.test_tryton
+from trytond.tests.test_tryton import POOL, DB_NAME, USER, CONTEXT
+from trytond.transaction import Transaction
+from trytond.exceptions import UserError
+
+
+class TestCurrency(unittest.TestCase):
+    """
+    Tests currency
+    """
+
+    def setUp(self):
+        """
+        Set up data used in the tests.
+        this method is called before each test function execution.
+        """
+        trytond.tests.test_tryton.install_module('magento')
+
+    def test_0010_get_currency_using_magento_code(self):
+        """
+        Tests if currency can be searched using magento code.
+        """
+        Currency = POOL.get('currency.currency')
+
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+
+            # Create currencies
+            currency1, currency2 = Currency.create([
+                {
+                    'name': 'US Dollar',
+                    'code': 'USD',
+                    'symbol': '$',
+                    'rounding': Decimal('1'),
+                }, {
+                    'name': 'Indian Rupee',
+                    'code': 'INR',
+                    'symbol': 'Rs',
+                    'rounding': Decimal('1'),
+                }
+            ])
+            self.assert_(currency1)
+            self.assert_(currency2)
+
+            # Search currency with valid code
+            self.assertEqual(
+                Currency.search_using_magento_code('USD'), currency1
+            )
+            self.assertEqual(
+                Currency.search_using_magento_code('INR'), currency2
+            )
+
+            # Try to search currency with invalid code
+            self.assertRaises(
+                UserError, Currency.search_using_magento_code, 'abc'
+            )
+
+
+def suite():
+    """
+    Test Suite
+    """
+    test_suite = trytond.tests.test_tryton.suite()
+    test_suite.addTests(
+        unittest.TestLoader().loadTestsFromTestCase(TestCurrency)
+    )
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())


### PR DESCRIPTION
Patch adds search_using_magento_code classmethod to currency model. This
method searches for currency using code given by magento. If succeed
return currency active record otherwise raise user error.

Task ID: project-1984/task-2169
Review ID: 315001
