### PR TITLE
Import carriers from magento #2175

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,6 +21,7 @@ from product import (
 from country import Country, Subdivision
 from sale import MagentoOrderState
 from currency import Currency
+from carrier import MagentoInstanceCarrier
 
 
 def register():
@@ -32,6 +33,7 @@ def register():
         InstanceWebsite,
         WebsiteStore,
         WebsiteStoreView,
+        MagentoInstanceCarrier,
         TestConnectionStart,
         ImportWebsitesStart,
         ExportInventoryStart,

--- a/carrier.py
+++ b/carrier.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+    carrier
+
+    Magento Carrier
+
+    :copyright: (c) 2013 by Openlabs Technologies & Consulting (P) Limited
+    :license: BSD, see LICENSE for more details.
+"""
+from trytond.model import ModelView, ModelSQL, fields
+from trytond.transaction import Transaction
+
+
+__all__ = [
+    'MagentoInstanceCarrier',
+]
+
+
+class MagentoInstanceCarrier(ModelSQL, ModelView):
+    """
+    Magento Instance carrier
+
+    This model stores the carriers / shipping methods imported from magento
+    each record here can be mapped to a carrier in tryton which will
+    then be used for managing export of tracking info to magento.
+    """
+    __name__ = 'magento.instance.carrier'
+    _rec_name = 'title'
+
+    code = fields.Char("Code", readonly=True)
+    carrier = fields.Many2One('carrier', 'Carrier')
+    title = fields.Char('Title', readonly=True)
+    instance = fields.Many2One(
+        'magento.instance', 'Magento Instance', readonly=True
+    )
+
+    @classmethod
+    def __setup__(cls):
+        """
+        Setup the class before adding to pool
+        """
+        super(MagentoInstanceCarrier, cls).__setup__()
+        cls._sql_constraints += [
+            (
+                'code_instance_unique', 'unique(code, instance)',
+                'Shipping methods must be unique in instance'
+            )
+        ]
+
+    @classmethod
+    def create_all_using_magento_data(cls, magento_data):
+        """
+        Creates record for list of carriers sent by magento.
+        It creates a new carrier only if one with the same code does not
+        exist for this instance.
+
+        :param magento_data: List of Dictionary of carriers sent by magento
+        :return: List of active records of carriers Created/Found
+        """
+        carriers = []
+        for data in magento_data:
+            carrier = cls.find_using_magento_data(data)
+            if carrier:
+                carriers.append(carrier)
+            else:
+                # Create carrier if not found
+                carriers.append(cls.create_using_magento_data(data))
+        return carriers
+
+    @classmethod
+    def create_using_magento_data(cls, carrier_data):
+        """
+         Create record for carrier data sent by magento
+
+        :param carrier_data: Dictionary of carrier sent by magento
+        :return: Active record of carrier created
+        """
+        carrier, = cls.create([{
+            'code': carrier_data['code'],
+            'title': carrier_data['label'],
+            'instance': Transaction().context['magento_instance'],
+        }])
+
+        return carrier
+
+    @classmethod
+    def find_using_magento_data(cls, carrier_data):
+        """
+        Search for an existing carrier by matching code and instance.
+        If found, return its active record else None
+
+        :param carrier_data: Dictionary of carrier sent by magento
+        :return: Active record of carrier found or None
+        """
+        try:
+            carrier, = cls.search([
+                ('code', '=', carrier_data['code']),
+                ('instance', '=', Transaction().context['magento_instance']),
+            ])
+        except ValueError:
+            return None
+        else:
+            return carrier

--- a/magento.xml
+++ b/magento.xml
@@ -159,6 +159,13 @@
             <field name="name">wizard_import_websites_start_form</field>
         </record>
 
+        <!--Import Carriers Wizard-->
+        <record model="ir.action.wizard" id="wizard_import_carriers">
+            <field name="name">Import Carriers</field>
+            <field name="wiz_name">magento.wizard_import_carriers</field>
+            <field name="model">magento.instance</field>
+        </record>
+
         <!--Order states-->
         <record model="ir.ui.view" id="order_state_view_form">
             <field name="model">magento.order_state</field>
@@ -214,6 +221,18 @@
             <field name="model">magento.wizard_export_inventory.start</field>
             <field name="type">form</field>
             <field name="name">export_inventory_start_form</field>
+        </record>
+
+        <!--Carriers-->
+        <record model="ir.ui.view" id="carrier_view_form">
+            <field name="model">magento.instance.carrier</field>
+            <field name="type">form</field>
+            <field name="name">magento_carrier_form</field>
+        </record>
+        <record model="ir.ui.view" id="carrier_view_tree">
+            <field name="model">magento.instance.carrier</field>
+            <field name="type">tree</field>
+            <field name="name">magento_carrier_tree</field>
         </record>
 
     </data>

--- a/tests/json/carriers/shipping_methods.json
+++ b/tests/json/carriers/shipping_methods.json
@@ -1,0 +1,14 @@
+[
+ {
+  "code": "flatrate", 
+  "label": "Flat Rate"
+ }, 
+ {
+  "code": "dhlint", 
+  "label": "DHL"
+ }, 
+ {
+  "code": "googlecheckout", 
+  "label": "googlecheckout"
+ }
+]

--- a/tests/test_sale.py
+++ b/tests/test_sale.py
@@ -132,6 +132,31 @@ class TestSale(TestBase):
             }
         )
 
+    def test_0020_import_carriers(self):
+        """
+        Test If all carriers are being imported from magento
+        """
+        MagentoCarrier = POOL.get('magento.instance.carrier')
+
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+            self.setup_defaults()
+
+            carriers_before_import = MagentoCarrier.search([])
+            with Transaction().set_context({
+                    'magento_instance': self.instance1.id
+            }):
+                carriers = MagentoCarrier.create_all_using_magento_data(
+                    load_json('carriers', 'shipping_methods')
+                )
+                carriers_after_import = MagentoCarrier.search([])
+
+                self.assertTrue(carriers_after_import > carriers_before_import)
+                for carrier in carriers:
+                    self.assertEqual(
+                        carrier.instance.id,
+                        Transaction().context['magento_instance']
+                    )
+
 
 def suite():
     """

--- a/tryton.cfg
+++ b/tryton.cfg
@@ -3,6 +3,7 @@ version=2.8.0
 depends:
     sale
     party
+    carrier
 xml:
     magento.xml
     party.xml

--- a/view/instance_form.xml
+++ b/view/instance_form.xml
@@ -23,8 +23,12 @@
         <page string="Order States" id="order_states">
             <field name="order_states"/>
         </page>
+        <page string="Carrier / Shipping Methods" id="carriers">
+            <field name="carriers"/>
+        </page>
     </notebook>
     <button string="Test Connection" name="test_connection" colspan="2"/>
     <button string="Import Websites" name="import_websites" colspan="2"/>
     <button string="Import Order states" name="import_order_states" colspan="2"/>
+    <button string="Import Shipping Mathods" name="import_carriers" colspan="2"/>
 </form>

--- a/view/magento_carrier_form.xml
+++ b/view/magento_carrier_form.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<form string="Magento Carriers / Shipping Methods" col="4">
+    <label name="title"/>
+    <field name="title"/>
+    <label name="code"/>
+    <field name="code"/>
+    <newline/>
+    <label name="carrier"/>
+    <field name="carrier"/>
+    <label name="instance"/>
+    <field name="instance"/>
+</form>

--- a/view/magento_carrier_tree.xml
+++ b/view/magento_carrier_tree.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<tree string="Magento Carriers / Shipping Methods">
+    <field name="title"/>
+    <field name="code"/>
+    <field name="carrier"/>
+    <field name="instance"/>
+</tree>

--- a/view/wizard_import_carriers_start_form.xml
+++ b/view/wizard_import_carriers_start_form.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<form string="Import Carriers / Shipping Methods">
+    <label id="status" string="
+        This wizard has imported all the
+        carriers / shipping methods for this
+        magento instance. You should now configure the
+        import carriers / shipping methods to match the
+        shipment carriers in Tryton to allow seamless
+        synchronisation of tracking information."/>
+</form>


### PR DESCRIPTION
Import carriers / shipping methods from magento.
Allow user to link each one to a carrier in tryton.
This carrier will be used while exporting shipping information to magento.

Review: 318001
