### PR TITLE
Export tier prices from tryton to magento #2074

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,12 +11,14 @@ from trytond.pool import Pool
 from magento_ import (
     Instance, InstanceWebsite, WebsiteStore, WebsiteStoreView,
     TestConnectionStart, TestConnection, ImportWebsitesStart, ImportWebsites,
-    ExportInventoryStart, ExportInventory
+    ExportInventoryStart, ExportInventory, StorePriceTier,
+    ExportTierPricesStart, ExportTierPrices, ExportTierPricesStatus,
 )
 from party import Party, MagentoWebsiteParty, Address
 from product import (
     Category, MagentoInstanceCategory, Template, MagentoWebsiteTemplate,
-    ImportCatalogStart, ImportCatalog, UpdateCatalogStart, UpdateCatalog
+    ImportCatalogStart, ImportCatalog, UpdateCatalogStart, UpdateCatalog,
+    ProductPriceTier,
 )
 from country import Country, Subdivision
 from sale import MagentoOrderState
@@ -32,11 +34,14 @@ def register():
         Instance,
         InstanceWebsite,
         WebsiteStore,
+        StorePriceTier,
         WebsiteStoreView,
         MagentoInstanceCarrier,
         TestConnectionStart,
         ImportWebsitesStart,
         ExportInventoryStart,
+        ExportTierPricesStart,
+        ExportTierPricesStatus,
         Country,
         Subdivision,
         Party,
@@ -45,6 +50,7 @@ def register():
         MagentoInstanceCategory,
         Template,
         MagentoWebsiteTemplate,
+        ProductPriceTier,
         ImportCatalogStart,
         MagentoOrderState,
         Address,
@@ -56,6 +62,7 @@ def register():
         TestConnection,
         ImportWebsites,
         ExportInventory,
+        ExportTierPrices,
         ImportCatalog,
         UpdateCatalog,
         module='magento', type_='wizard'

--- a/magento.xml
+++ b/magento.xml
@@ -104,6 +104,18 @@
             <field name="name">magento_product_template_tree</field>
         </record>
 
+        <!-- Store Price Tiers -->
+        <record model="ir.ui.view" id="store_price_tier_view_form">
+            <field name="model">magento.store.price_tier</field>
+            <field name="type">form</field>
+            <field name="name">store_price_tier_form</field>
+        </record>
+        <record model="ir.ui.view" id="store_price_tier_view_tree">
+            <field name="model">magento.store.price_tier</field>
+            <field name="type">tree</field>
+            <field name="name">store_price_tier_tree</field>
+        </record>
+
         <!--Website Store View-->
         <record model="ir.ui.view" id="store_view_form">
             <field name="model">magento.store.store_view</field>
@@ -233,6 +245,28 @@
             <field name="model">magento.instance.carrier</field>
             <field name="type">tree</field>
             <field name="name">magento_carrier_tree</field>
+        </record>
+
+        <!--Export Tier Prices Wizard-->
+        <record model="ir.action.wizard" id="wizard_export_tier_prices">
+            <field name="name">Export Tier Prices to Magento</field>
+            <field name="wiz_name">magento.wizard_export_tier_prices</field>
+            <field name="model">magento.website.store</field>
+        </record>
+        <record model="ir.action.keyword" id="wizard_export_tier_prices_keyword">
+            <field name="keyword">form_action</field>
+            <field name="model">magento.website.store,-1</field>
+            <field name="action" ref="wizard_export_tier_prices"/>
+        </record>
+        <record model="ir.ui.view" id="wizard_export_tier_prices_view_start_form">
+            <field name="model">magento.wizard_export_tier_prices.start</field>
+            <field name="type">form</field>
+            <field name="name">export_tier_prices_start_form</field>
+        </record>
+        <record model="ir.ui.view" id="wizard_export_tier_prices_view_status_form">
+            <field name="model">magento.wizard_export_tier_prices.status</field>
+            <field name="type">form</field>
+            <field name="name">export_tier_prices_status_form</field>
         </record>
 
     </data>

--- a/product.xml
+++ b/product.xml
@@ -33,6 +33,17 @@ this repository contains the full copyright notices and license terms. -->
           <field name="name">template_tree</field>
         </record>
 
+        <record model="ir.ui.view" id="product_price_tier_view_form">
+            <field name="model">product.price_tier</field>
+            <field name="type">form</field>
+            <field name="name">product_price_tier_form</field>
+        </record>
+        <record model="ir.ui.view" id="product_price_tier_view_tree">
+            <field name="model">product.price_tier</field>
+            <field name="type">tree</field>
+            <field name="name">product_price_tier_tree</field>
+        </record>
+
         <!--Wizard View-->
         <record model="ir.action.wizard" id="wizard_instance_import_catalog">
             <field name="name">Import Magento Product Catalog</field>

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -8,9 +8,17 @@
 import os
 import json
 import unittest
+from datetime import datetime
 
+from dateutil.relativedelta import relativedelta
 import trytond.tests.test_tryton
-from trytond.tests.test_tryton import POOL
+from trytond.tests.test_tryton import POOL, USER
+from trytond.transaction import Transaction
+
+
+ROOT_JSON_FOLDER = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), 'json'
+)
 
 
 def load_json(resource, filename):
@@ -24,18 +32,15 @@ def load_json(resource, filename):
                        |
                        filename
 
-    :param resource: The prestashop resource for which the file has to be
+    :param resource: The magento resource for which the file has to be
                      fetched. It is same as the folder name in which the files
                      are kept.
     :param filename: The name of the file to be fethced without `.json`
                      extension.
     :returns: Loaded json from the contents of the file read.
     """
-    root_json_folder = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), 'json'
-    )
     file_path = os.path.join(
-        root_json_folder, resource, str(filename)
+        ROOT_JSON_FOLDER, resource, str(filename)
     ) + '.json'
 
     return json.loads(open(file_path).read())
@@ -65,19 +70,36 @@ class TestBase(unittest.TestCase):
         Currency = POOL.get('currency.currency')
         Company = POOL.get('company.company')
         Party = POOL.get('party.party')
+        User = POOL.get('res.user')
+        FiscalYear = POOL.get('account.fiscalyear')
+        Sequence = POOL.get('ir.sequence')
+        SequenceStrict = POOL.get('ir.sequence.strict')
+        AccountTemplate = POOL.get('account.account.template')
+        CreateChartAccount = POOL.get(
+            'account.create_chart', type="wizard"
+        )
+        Account = POOL.get('account.account')
+        PaymentTerm = POOL.get('account.invoice.payment_term')
 
-        self.party, = Party.create([{
-            'name': 'ABC',
-        }])
         self.usd, = Currency.create([{
             'name': 'US Dollar',
             'code': 'USD',
             'symbol': '$',
         }])
-        self.company, = Company.create([{
-            'party': self.party.id,
-            'currency': self.usd.id,
-        }])
+
+        with Transaction().set_context(company=None):
+            self.party, = Party.create([{
+                'name': 'ABC',
+            }])
+            self.company, = Company.create([{
+                'party': self.party.id,
+                'currency': self.usd.id,
+            }])
+
+        User.write([User(USER)], {
+            'main_company': self.company.id,
+            'company': self.company.id,
+        })
 
         # Create two instances
         self.instance1, = Instance.create([{
@@ -126,3 +148,93 @@ class TestBase(unittest.TestCase):
             'store': self.store,
             'code': '123',
         }])
+
+        date = datetime.utcnow().date()
+
+        with Transaction().set_context(
+            User.get_preferences(context_only=True)
+        ):
+            invoice_sequence, = SequenceStrict.create([{
+                'name': '%s' % date.year,
+                'code': 'account.invoice',
+                'company': self.company.id,
+            }])
+            fiscal_year, = FiscalYear.create([{
+                'name': '%s' % date.year,
+                'start_date': date + relativedelta(month=1, day=1),
+                'end_date': date + relativedelta(month=12, day=31),
+                'company': self.company.id,
+                'post_move_sequence': Sequence.create([{
+                    'name': '%s' % date.year,
+                    'code': 'account.move',
+                    'company': self.company.id,
+                }])[0].id,
+                'out_invoice_sequence': invoice_sequence.id,
+                'in_invoice_sequence': invoice_sequence.id,
+                'out_credit_note_sequence': invoice_sequence.id,
+                'in_credit_note_sequence': invoice_sequence.id,
+            }])
+            FiscalYear.create_period([fiscal_year])
+
+            account_template, = AccountTemplate.search(
+                [('parent', '=', None)]
+            )
+
+            session_id, _, _ = CreateChartAccount.create()
+            create_chart = CreateChartAccount(session_id)
+            create_chart.account.account_template = account_template
+            create_chart.account.company = self.company
+            create_chart.transition_create_account()
+            revenue, = Account.search([
+                ('kind', '=', 'revenue'),
+                ('company', '=', self.company.id),
+            ])
+            receivable, = Account.search([
+                ('kind', '=', 'receivable'),
+                ('company', '=', self.company.id),
+            ])
+            payable, = Account.search([
+                ('kind', '=', 'payable'),
+                ('company', '=', self.company.id),
+            ])
+            expense, = Account.search([
+                ('kind', '=', 'expense'),
+                ('company', '=', self.company.id),
+            ])
+            create_chart.properties.company = self.company
+            create_chart.properties.account_receivable = receivable
+            create_chart.properties.account_payable = payable
+            create_chart.properties.account_revenue = revenue
+            create_chart.properties.account_expense = expense
+            create_chart.transition_create_properties()
+
+            Party.write(
+                [Party(self.party)], {
+                    'account_payable': payable.id,
+                    'account_receivable': receivable.id,
+                }
+            )
+            PaymentTerm.create([{
+                'name': 'Direct',
+                'lines': [('create', [{'type': 'remainder'}])]
+            }])
+
+    def get_account_by_kind(self, kind, company=None, silent=True):
+        """Returns an account with given spec
+
+        :param kind: receivable/payable/expense/revenue
+        :param silent: dont raise error if account is not found
+        """
+        Account = POOL.get('account.account')
+        Company = POOL.get('company.company')
+
+        if company is None:
+            company, = Company.search([], limit=1)
+
+        accounts = Account.search([
+            ('kind', '=', kind),
+            ('company', '=', company.id)
+        ], limit=1)
+        if not accounts and not silent:
+            raise Exception("Account not found")
+        return accounts[0] if accounts else False

--- a/tests/test_website_import.py
+++ b/tests/test_website_import.py
@@ -9,7 +9,6 @@
 """
 import sys
 import os
-import json
 DIR = os.path.abspath(os.path.normpath(
     os.path.join(
         __file__,
@@ -22,75 +21,14 @@ if os.path.isdir(DIR):
 import unittest
 import trytond.tests.test_tryton
 from trytond.transaction import Transaction
+from test_base import TestBase, load_json
 from trytond.tests.test_tryton import POOL, USER, DB_NAME, CONTEXT
 
 
-ROOT_JSON_FOLDER = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), 'json'
-)
-
-
-def load_json(resource, filename):
-    """Reads the json file from the filesystem and returns the json loaded as
-    python objects
-
-    On filesystem, the files are kept in this format:
-        json----
-              |
-            resource----
-                       |
-                       filename
-
-    :param resource: The prestashop resource for which the file has to be
-                     fetched. It is same as the folder name in which the files
-                     are kept.
-    :param filename: The name of the file to be fethced without `.json`
-                     extension.
-    :returns: Loaded json from the contents of the file read.
-    """
-    file_path = os.path.join(
-        ROOT_JSON_FOLDER, resource, str(filename)
-    ) + '.json'
-
-    return json.loads(open(file_path).read())
-
-
-class TestWebsiteImport(unittest.TestCase):
+class TestWebsiteImport(TestBase):
     '''
     Tests import of Magento Websites, Stores and StoreViews
     '''
-
-    def setUp(self):
-        """
-        Set up data used in the tests.
-        this method is called before each test function execution.
-        """
-        trytond.tests.test_tryton.install_module('magento')
-
-    def setup_defaults(self):
-        """
-        Create setup defaults
-        """
-        Currency = POOL.get('currency.currency')
-        Company = POOL.get('company.company')
-        Party = POOL.get('party.party')
-
-        party, = Party.create([{
-            'name': 'ABC',
-        }])
-        usd, = Currency.create([{
-            'name': 'US Dollar',
-            'code': 'USD',
-            'symbol': '$',
-        }])
-        company, = Company.create([{
-            'party': party.id,
-            'currency': usd.id,
-        }])
-
-        return {
-            'company': company
-        }
 
     def test_0010_import_websites(self):
         """Test the import of websites
@@ -99,8 +37,8 @@ class TestWebsiteImport(unittest.TestCase):
         Website = POOL.get('magento.instance.website')
 
         with Transaction().start(DB_NAME, USER, CONTEXT) as txn:
-            data = self.setup_defaults()
-            with txn.set_context({'company': data['company']}):
+            self.setup_defaults()
+            with txn.set_context({'company': self.company.id}):
                 instance, = Instance.create([{
                     'name': 'Test Instance',
                     'url': 'some test url',
@@ -123,8 +61,8 @@ class TestWebsiteImport(unittest.TestCase):
         Store = POOL.get('magento.website.store')
 
         with Transaction().start(DB_NAME, USER, CONTEXT) as txn:
-            data = self.setup_defaults()
-            with txn.set_context({'company': data['company']}):
+            self.setup_defaults()
+            with txn.set_context({'company': self.company.id}):
                 instance, = Instance.create([{
                     'name': 'Test Instance',
                     'url': 'some test url',
@@ -152,8 +90,8 @@ class TestWebsiteImport(unittest.TestCase):
         StoreView = POOL.get('magento.store.store_view')
 
         with Transaction().start(DB_NAME, USER, CONTEXT) as txn:
-            data = self.setup_defaults()
-            with txn.set_context({'company': data['company']}):
+            self.setup_defaults()
+            with txn.set_context({'company': self.company.id}):
                 instance, = Instance.create([{
                     'name': 'Test Instance',
                     'url': 'some test url',

--- a/tryton.cfg
+++ b/tryton.cfg
@@ -4,6 +4,7 @@ depends:
     sale
     party
     carrier
+    product_price_list
 xml:
     magento.xml
     party.xml

--- a/view/export_tier_prices_start_form.xml
+++ b/view/export_tier_prices_start_form.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!-- This file is part of Tryton. The COPYRIGHT file at the top level of
+this repository contains the full copyright notices and license terms. -->
+<form string="Export Tier Prices" col="2">
+    <image name="tryton-dialog-information" xexpand="0" xfill="0"/>
+    <label string="This wizard will export product tier prices to magento for this store."
+        id="choose" yalign="0.0" xalign="0.0" xexpand="1"/>
+</form>

--- a/view/export_tier_prices_status_form.xml
+++ b/view/export_tier_prices_status_form.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!-- This file is part of Tryton. The COPYRIGHT file at the top level of
+this repository contains the full copyright notices and license terms. -->
+<form string="Export Tier Prices" col="2">
+    <label name="products_count"/>
+    <field name="products_count"/>
+</form>

--- a/view/product_price_tier_form.xml
+++ b/view/product_price_tier_form.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!-- This file is part of Tryton. The COPYRIGHT file at the top level of
+this repository contains the full copyright notices and license terms. -->
+<form string="Price Tier" col="6">
+    <label name="quantity"/>
+    <field name="quantity"/>
+    <label name="template"/>
+    <field name="template"/>
+</form>

--- a/view/product_price_tier_tree.xml
+++ b/view/product_price_tier_tree.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!-- This file is part of Tryton. The COPYRIGHT file at the top level of
+this repository contains the full copyright notices and license terms. -->
+<tree string="Price Tiers">
+    <field name="quantity"/>
+    <field name="template"/>
+</tree>

--- a/view/store_form.xml
+++ b/view/store_form.xml
@@ -9,9 +9,14 @@
     <field name="company"/>
     <label name="instance"/>
     <field name="instance"/>
+    <label name="price_list"/>
+    <field name="price_list"/>
     <notebook>
         <page string="Store Views" id="store_views">
             <field name="store_views"/>
+        </page>
+        <page string="Price Tiers" id="price_tiers">
+            <field name="price_tiers"/>
         </page>
     </notebook>
 </form>

--- a/view/store_price_tier_form.xml
+++ b/view/store_price_tier_form.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!-- This file is part of Tryton. The COPYRIGHT file at the top level of
+this repository contains the full copyright notices and license terms. -->
+<form string="Price Tier" col="6">
+    <label name="quantity"/>
+    <field name="quantity"/>
+    <label name="store"/>
+    <field name="store"/>
+</form>

--- a/view/store_price_tier_tree.xml
+++ b/view/store_price_tier_tree.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!-- This file is part of Tryton. The COPYRIGHT file at the top level of
+this repository contains the full copyright notices and license terms. -->
+<tree string="Price Tiers">
+    <field name="quantity"/>
+    <field name="store"/>
+</tree>

--- a/view/template_form.xml
+++ b/view/template_form.xml
@@ -9,6 +9,7 @@ this repository contains the full copyright notices and license terms. -->
     <xpath expr="/form/notebook/page[@id='general']" position="after">
         <page string="Magento" id="magento_product_templates">
             <field name="magento_ids"/>
+            <field name="price_tiers"/>
         </page>
     </xpath>
 </data>


### PR DESCRIPTION
Allow users to define price tiers on products.
A default price tier table can be setup on store itself.
Calculate the tier prices using pricelist selected on store.
A wizard to export tier prices

Review: 323001
