### PR TITLE
Buttons to import/export orders #2437

### DIFF
--- a/magento.xml
+++ b/magento.xml
@@ -302,11 +302,6 @@
             <field name="wiz_name">magento.wizard_import_orders</field>
             <field name="model">magento.store.store_view</field>
         </record>
-        <record model="ir.action.keyword" id="wizard_import_orders_keyword">
-            <field name="keyword">form_action</field>
-            <field name="model">magento.store.store_view,-1</field>
-            <field name="action" ref="wizard_import_orders"/>
-        </record>
         <record model="ir.ui.view" id="wizard_import_orders_view_start_form">
             <field name="model">magento.wizard_import_orders.start</field>
             <field name="type">form</field>
@@ -318,11 +313,6 @@
             <field name="name">Export Order Status</field>
             <field name="wiz_name">magento.wizard_export_order_status</field>
             <field name="model">magento.store.store_view</field>
-        </record>
-        <record model="ir.action.keyword" id="wizard_export_order_status_keyword">
-            <field name="keyword">form_action</field>
-            <field name="model">magento.store.store_view,-1</field>
-            <field name="action" ref="wizard_export_order_status"/>
         </record>
         <record model="ir.ui.view" id="wizard_export_order_status_view_start_form">
             <field name="model">magento.wizard_export_order_status.start</field>

--- a/magento_.py
+++ b/magento_.py
@@ -614,6 +614,10 @@ class WebsiteStoreView(ModelSQL, ModelView):
             "states_not_found": 'No order states found for importing orders! '
                 'Please configure the order states on magento instance',
         })
+        cls._buttons.update({
+            'import_orders_button': {},
+            'export_order_status_button': {}
+        })
 
     @classmethod
     def find_or_create(cls, store, values):
@@ -641,6 +645,26 @@ class WebsiteStoreView(ModelSQL, ModelView):
             'store': store.id,
             'magento_id': int(values['store_id']),
         }])[0]
+
+    @classmethod
+    @ModelView.button_action('magento.wizard_import_orders')
+    def import_orders_button(cls, store_views):
+        """
+        Calls wizard to import orders for store view
+
+        :param store_views: List of active records of store views
+        """
+        pass
+
+    @classmethod
+    @ModelView.button_action('magento.wizard_export_order_status')
+    def export_order_status_button(cls, store_views):
+        """
+        Calls wizard to export order status for store view
+
+        :param store_views: List of active records of store views
+        """
+        pass
 
     def import_order_from_store_view(self):
         """

--- a/sale.py
+++ b/sale.py
@@ -20,7 +20,8 @@ from trytond.wizard import Wizard, StateView, Button, StateAction
 
 __all__ = [
     'MagentoOrderState', 'StockShipmentOut', 'Sale', 'SaleLine',
-    'ImportOrdersStart', 'ImportOrders',
+    'ImportOrdersStart', 'ImportOrders', 'ExportOrderStatusStart',
+    'ExportOrderStatus',
 ]
 __metaclass__ = PoolMeta
 

--- a/view/storeview_form.xml
+++ b/view/storeview_form.xml
@@ -11,8 +11,14 @@
     <field name="company"/>
     <label name="instance"/>
     <field name="instance"/>
-    <label name="last_order_import_time"/>
-    <field name="last_order_import_time"/>
-    <label name="last_order_export_time"/>
-    <field name="last_order_export_time"/>
+    <notebook>
+        <page id="export_import_time" string="Last Export / Import Time">
+            <label name="last_order_import_time"/>
+            <field name="last_order_import_time"/>
+            <label name="last_order_export_time"/>
+            <field name="last_order_export_time"/>
+        </page>
+    </notebook>
+    <button string="Import Orders" name="import_orders_button" colspan="2"/>
+    <button string="Export Order Status" name="export_order_status_button" colspan="2"/>
 </form>


### PR DESCRIPTION
This patch has removed action keywords to perform importing/exporting of
orders and added buttons to perform same functionality.

Review ID: 424001
