### PR TITLE
Fix date_format while fetching orders #6657

### DIFF
--- a/magento_.py
+++ b/magento_.py
@@ -706,8 +706,12 @@ class WebsiteStoreView(ModelSQL, ModelView):
                     'state': {'in': order_states_to_import_in},
                 }
                 if self.last_order_import_time:
+                    last_order_import_time = \
+                        self.last_order_import_time.replace(microsecond=0)
                     filter.update({
-                        'updated_at': {'gteq': self.last_order_import_time},
+                        'updated_at': {
+                            'gteq': last_order_import_time.isoformat(' ')
+                        },
                     })
                 self.write([self], {
                     'last_order_import_time': datetime.utcnow()


### PR DESCRIPTION
As magento allow user to delete product even if it is used in
sale_order, it will throw error when connector try to fetch product from
magento server.

Added a new model called magento exception and saving exception logs in
it.