### PR TITLE
Description is optional on magento order line

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -456,7 +456,7 @@ class Sale:
             values.update({
                 'sale': self.id,
                 'magento_id': int(item['item_id']),
-                'description': item['name'],
+                'description': item['name'] or product.name,
                 'unit_price': Decimal(item['price']),
                 'unit': unit.id,
                 'quantity': Decimal(item['qty_ordered']),


### PR DESCRIPTION
As craxy as it may sound, magento may send order line without any
description, but tryton needs it. So if the description is empty
fill that with the product's name.