### PR TITLE
Fixed issue of email being written to phone field

### DIFF
--- a/party.py
+++ b/party.py
@@ -121,7 +121,8 @@ class Party:
             ],
             'contact_mechanisms': [
                 ('create', [{
-                    'email': magento_data['email']
+                    'type': 'email',
+                    'value': magento_data['email'],
                 }])
             ]
         }])


### PR DESCRIPTION
The `Address` class handles import of `telephone` key as contact mechanism, so not handling that again in this case.