### PR TITLE
While creating sale line product's sale_uom should be respected

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -447,7 +447,7 @@ class Sale:
                 'magento_id': int(item['item_id']),
                 'description': item['name'] or product.name,
                 'unit_price': Decimal(item['price']),
-                'unit': unit.id,
+                'unit': (product and product.sale_uom.id) or unit.id,
                 'quantity': Decimal(item['qty_ordered']),
                 'note': item.get('comments'),
                 'product': product,


### PR DESCRIPTION
When importing sale order from magento, product's sale_uom should be respected